### PR TITLE
【バグ修正】プロフィール写真を更新後プロフィール画面に遷移しても画像が更新されていない

### DIFF
--- a/src/app/(authed)/profile/changeSetting/components/ChangeSettingForm.tsx
+++ b/src/app/(authed)/profile/changeSetting/components/ChangeSettingForm.tsx
@@ -42,6 +42,7 @@ export const ChangeSettingForm = ({
           description: "プロフィール画像を変更しました",
         })
       );
+      router.refresh();
     });
   };
   const onClickNameChangeButton = async () => {
@@ -52,6 +53,7 @@ export const ChangeSettingForm = ({
           description: "ユーザーネームを変更しました",
         });
       });
+      router.refresh();
     });
   };
   const onClickPasswordChangeButton = async (e: any) => {

--- a/src/servers/user/mutation.ts
+++ b/src/servers/user/mutation.ts
@@ -73,7 +73,6 @@ export const updateName = async (name: string) => {
       id: session?.user.userInfoId,
     },
   });
-  revalidatePath("/profile");
   return user;
 };
 
@@ -90,6 +89,5 @@ export const updateProfileImage = async (url: string) => {
       id: session?.user.userInfoId,
     },
   });
-  revalidatePath("/profile");
   return updatedUser;
 };


### PR DESCRIPTION
データベースは更新されている
調査中だが、revalidatePathではうまく更新されなかったのでrouter.refreshに戻す