### PR TITLE
Cronの実行時間をJST前提に変更する

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/ticket/schedule",
-      "schedule": "0 5 * * *"
+      "schedule": "0 20 * * *"
     }
   ]
 }


### PR DESCRIPTION
Vercel CronはUTC時間で実行されるが、日本国内で使用するアプリでは流石に不便なので修正
テストは明日の朝やる