### PR TITLE
グループ情報にメンバーアイコンを表示

### DIFF
--- a/src/app/(authed)/groups/_components/GroupInfo.tsx
+++ b/src/app/(authed)/groups/_components/GroupInfo.tsx
@@ -5,6 +5,7 @@ import { useQRCode } from "next-qrcode";
 import { GroupInviteButton } from "~/app/(authed)/groups/_components/info/GroupInviteButton";
 import { Button } from "~/components/common";
 import { useToast } from "~/components/common/use-toast";
+import { GroupAvatarImage } from "~/components/domain/group/GroupAvatarImage";
 import { deleteGroup } from "~/servers/group/mutation";
 import { leaveGroup } from "~/servers/user/mutation";
 
@@ -50,9 +51,14 @@ export const GroupInfo = ({
         <h4 className="mt-4 text-xl font-semibold tracking-tight">
           グループメンバー
         </h4>
-        <ul className="mt-2">
+        <ul className="flex items-center mt-2 gap-2 flex-wrap">
           {groupUsers?.map((user) => (
-            <li key={user.id}>{user.name}</li>
+            <li key={user.id}>
+              <GroupAvatarImage
+                imageUrl={user.profileImageUrl!}
+                name={user.name}
+              />
+            </li>
           ))}
         </ul>
         <div className="mt-2">

--- a/src/app/(authed)/groups/_components/GroupsWrapper.tsx
+++ b/src/app/(authed)/groups/_components/GroupsWrapper.tsx
@@ -1,5 +1,6 @@
 import { GroupInfo } from "~/app/(authed)/groups/_components/GroupInfo";
 import { GroupsForm } from "~/app/(authed)/groups/_components/GroupsForm";
+import { getDownloadURLFromStorage } from "~/lib/firebase/storageServer";
 import { getGroup, groupHistory } from "~/servers/group/query";
 import { getLoginUser, getUserByGroup } from "~/servers/user/query";
 
@@ -12,12 +13,21 @@ export const GroupsWrapper = async () => {
     return <GroupsForm user={user} />;
   }
   const users = await getUserByGroup(user.groupId);
-  const ticketGroupHistory = await groupHistory(users.map((u) => u.id));
+  const [ticketGroupHistory, ...usesrWithProfileImage] = await Promise.all([
+    groupHistory(users.map((u) => u.id)),
+    ...users.map(async (u) => {
+      const imageUrl = await getDownloadURLFromStorage(u?.profileImageUrl);
+      return {
+        ...u,
+        profileImageUrl: imageUrl ?? null,
+      };
+    }),
+  ]);
   return (
     <GroupInfo
       group={group}
       user={user}
-      groupUsers={users}
+      groupUsers={usesrWithProfileImage}
       ticketGroupHistory={ticketGroupHistory}
     />
   );

--- a/src/components/domain/group/GroupAvatarImage.tsx
+++ b/src/components/domain/group/GroupAvatarImage.tsx
@@ -1,0 +1,22 @@
+import Image from "next/image";
+
+type GroupAvatarImageProps = {
+  imageUrl?: string;
+  name: string;
+};
+
+export const GroupAvatarImage = ({ imageUrl, name }: GroupAvatarImageProps) => {
+  return (
+    <figure className="flex flex-col items-center gap-1">
+      <div className="relative w-14 h-14">
+        <Image
+          src={imageUrl ?? "/noimage.png"}
+          className="rounded-full border"
+          alt="Avatar"
+          fill={true}
+        />
+      </div>
+      <figcaption className="text-xs break-all">{name}</figcaption>
+    </figure>
+  );
+};


### PR DESCRIPTION
グループ情報にメンバーアイコンを表示して見栄えをよくする

<img width="359" alt="スクリーンショット 2023-05-29 21 13 47" src="https://github.com/skyt-a/Katacky/assets/36734151/d3d49fb2-ca6b-47ef-a283-b82a42ee2538" width=300>
